### PR TITLE
Fix for .scss files containing only variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ module.exports = function (snowpackConfig, pluginOptions) {
             const content = await delegate.load({filePath, isDev});
             if (content) {
                 return accept(filePath) ? cssResultModule(content) : cssProxyModule(content);
+            } else {
+                return '';
             }
         }
     };


### PR DESCRIPTION
If the sass build returns an empty string (.scss files containing only variables for example), the build currently fails with error "Requested content ".js" but built .scss.". This would fix it.