### PR TITLE
Fixed `this.markChanged` not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
         name: "snowpack-plugin-css-result",
         resolve: {input: [".scss", ".sass"], output: [".js"]},
         onChange(args) {
+            delegate.markChanged = this.markChanged;
             delegate.onChange(args);
         },
         async load({filePath, isDev}) {


### PR DESCRIPTION
In dev mode (with hot module reloading), making changes to a .scss file that is imported from another .scss file triggers the following error:
```
[17:29:02] [snowpack] (node:71438) UnhandledPromiseRejectionWarning: TypeError: this.markChanged is not a function
    at Object._markImportersAsChanged (/Users/juliendelort/coding/blox/node_modules/@snowpack/plugin-sass/plugin.js:111:16)
    at Object.onChange (/Users/juliendelort/coding/blox/node_modules/@snowpack/plugin-sass/plugin.js:123:12)
    at Object.onChange (/Users/juliendelort/coding/blox/node_modules/snowpack-plugin-css-result/index.js:33:22)
    at onWatchEvent (/Users/juliendelort/coding/blox/node_modules/snowpack/lib/index.js:183051:39)
    at async FSWatcher.<anonymous> (/Users/juliendelort/coding/blox/node_modules/snowpack/lib/index.js:183079:13)
(Use `node --trace-warnings ...` to show where the warning was created)
[17:29:02] [snowpack] (node:71438) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
[17:29:02] [snowpack] (node:71438) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

For example, if `index.js` imports `index.scss` which imports `something.scss`, then making a change to `something.scss` would trigger the above error during live reloading.

This is due to [@snowpack/plugin-sass calling this.markChanged()](https://github.com/withastro/snowpack/blob/c44d86f73ac7b74507d4d5554ccb96e8b7dc5294/plugins/plugin-sass/plugin.js#L111). `this.markChanged()` is a [valid snowpack plugin method](https://www.snowpack.dev/reference/plugins#plugin-methods) that is available inside plugin hooks. But since this directly calls the `onChange()` sass plugin hook, I believe it is not forwarded.

This change fixed the error mentioned above.